### PR TITLE
Typography correction

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -109,7 +109,7 @@ impl RemoteWatcher {
                 remote_event.fields["content"]
                     .as_object()
                     .ok_or(Error::UnexpectedError(format!(
-                        "Remote event content not appear to not be obect"
+                        "Remote event content not appear to not be object"
                     )))?["content_id"]
                     .as_i64()
                     .ok_or(Error::UnexpectedError(format!(


### PR DESCRIPTION
Salut,
Code très lisible, agréable à lire :)

Je passais juste lire un peu et j'ai vu une faute de frappe
J'aurai même privilégié une phrase du style
"Remote event content not appear to be an object"

Bonne journée