### PR TITLE
Fix Tracim website URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![trsync illustration](illustration2.png)
 
-Synchronize local folder with remote [Tracim](https://www.algoo.fr/fr/tracim) shared spaces.
+Synchronize local folder with remote [Tracim](https://tracim.fr) shared spaces.
 
 ## What is in this repository
 


### PR DESCRIPTION
Tracim now has a dedicated website, so the URL would need to be updated in the readme (there is no redirect from the old URL).

See you,
Yvan