### PR TITLE
Ease onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Synchronize local folder with remote [Tracim](https://tracim.fr) shared spaces.
 * **configure** : The configuration window for manager config file
 * **systray** : Task bar icon program permitting to start a graphical configuration window to fill manager config file.
 
+## Requirements
+- Open SSL 1.1 lib
+- `secret-tool` command (`libsecret-tools` apt package)
+
 ## Build from source
 
 GNU/Linux 🐧 : Please install following dependencies, example for Debian-like :
@@ -57,7 +61,7 @@ Example :
 
     cargo run ~/Tracim/MyProject mon.tracim.fr 42 bux
 
-User password will be asked by prompt. To use environment variable, indicate environment variable containg password name with `--env-var-pass PASSWORD` where `PASSWORD` is the environment variable name.
+User password will be asked by prompt. To use environment variable, indicate environment variable containing password name with `--env-var-pass PASSWORD` where `PASSWORD` is the environment variable name.
 
 ### manager
 
@@ -76,8 +80,6 @@ The `libappindicator` package is required. Example for debian-like:
     apt-get install libappindicator3-1
 
 ⚠ If you run Debian 11 + Gnome Shell, you must install following gnome extension : https://extensions.gnome.org/extension/615/appindicator-support/.
-
-You need [trsync-manager-configure](https://github.com/buxx/trsync-manager-configure) on your system.
 
 You need a configuration file like at previous "manager" section.
 

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -22,7 +22,7 @@ Each user which will use TrSync must have a configuration file at :
 
 * `/home/<username>/.trsync.conf`
 
-This file must contains :
+This file must contain :
 
 ```ini
 [server]
@@ -35,12 +35,14 @@ At this step, TrSync can be started by executing `/usr/bin/trsync-manager-config
 
 ## TrSync as Application
 
-To permit start TrSync though graphical menus, create following file :
+1. To permit start TrSync though graphical menus, create a .desktop file (see content below):
+   * `/home/<username>/.local/share/applications` if install for one or some user only
+   * `/usr/share/applications` if install for all users
+2. Copy all .png files from `systray` folder to:
+   * `/home/<username>/.local/share/icons/` if install for current user only
+   * `/usr/share/icons` if install for all users.
 
-* `/home/<username>/.local/share/applications` if install for one or some user only
-* `/usr/share/applications` if install for all users
-
-This file must contains :
+This desktop file must contain :
 
 ```ini
 [Desktop Entry]
@@ -53,15 +55,13 @@ Name=TrSync
 Icon=</home/<username>/.local/share/icons/trsync.png if install for current user only, /usr/share/icons/trsync.png if install for all users>
 ```
 
-Copy all .png files from `systray` folder to `/home/<username>/.local/share/icons/` if install for current user only, `/usr/share/icons` if install for all users.
-
 ## Auto startup
 
 For concerned users, create following file :
 
 * `/home/<username>/.config/autostart/trsync-manager-systray.desktop`
 
-This file must contains :
+This file must contain :
 
 ```ini
 [Desktop Entry]

--- a/trsync.conf.tpl
+++ b/trsync.conf.tpl
@@ -1,6 +1,7 @@
 [server]
 instances = algoo,bux
 local_folder = /home/<your user>/Tracim
+icons_path = </home/<username>/.local/share/icons if install for one or some user only, /usr/share/icons if install for all users>
 
 [instance.algoo]
 address = algoo.tracim.fr


### PR DESCRIPTION
Hello, 

I've just installed TrSync on Debian 13, thanks for your work !

To ease onboarding I'm proposing those modifications : 
- trsync.conf.tpl : add the missing icons_path key (generates an error on binary launch)
- README
   - add new requirements chapter (openssl 1.1, package to install secret_tool command)
   - remove trsync-manager-configure mention (see buxx/trsync#84)
- deployment : I missed the icons step, so I'm proposing this little change that should make it clearer there are 2 distinct steps to follow ?